### PR TITLE
just a small bug fix

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -91,7 +91,7 @@ class DateTimeWidget(MultiWidget):
         except ValueError:
             return ''
         else:
-            return str(D)
+            return D.strftime(self.format)
 
     def decompress(self, value):
         if value:


### PR DESCRIPTION
- format the output in the same way that we
  expect the input, otherwise the widget can't
  parse it and the datetime gets empty; this
  can happen if the form is re-submitted due
  to an error in a different form field.
