### PR TITLE
Fixing syntax error when installing on Python 3.2.

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -131,7 +131,7 @@ class DateTimeWidget(MultiWidget):
         ]
         try:
             D = to_current_timezone(datetime.strptime(date_time[0], self.format))
-        except (ValueError, TypeError), e:
+        except (ValueError, TypeError):
             return ''
         else:
             return D


### PR DESCRIPTION
Got a syntax error when I pip installed the package on a Python 3.2 virtualenv.
