### PR TITLE
Removed trailing comma in last line of datetimepicker_options which breaks widget in IE8

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -36,7 +36,7 @@ datetimepicker_options = """
     pickerPosition : '%s',
     showMeridian : %s,
     clearBtn : %s,
-    language : '%s',
+    language : '%s'
 """
 
 dateConversiontoPython = {


### PR DESCRIPTION
Removed trailing comma in last line of datetimepicker_options which breaks widget in IE8
