### PR TITLE
Python3 compatibility fix

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -131,7 +131,7 @@ class DateTimeWidget(MultiWidget):
         ]
         try:
             D = to_current_timezone(datetime.strptime(date_time[0], self.format))
-	except (ValueError, TypeError) as e :
+        except (ValueError, TypeError) as e :
             return ''
         else:
             return D


### PR DESCRIPTION
Use except .. as instead of the obsoleted comma syntax.
