### PR TITLE
Provide Javascript helper object

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -165,6 +165,28 @@ def quote(key, value):
     return value
 
 
+class Javascript(object):
+    """Object to help inject Javascript code into options settings that get quoted if they
+    are strings. This gets around the issue by not being a string-type and injecting the code
+    without quotes in the __str__ method. Example:
+
+       # Sets the iniital date to 7pm on the client's current date
+       >>> options = {
+           'initialDate': Javascript('''function() {
+                var now = new Date();
+                var seven = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 19, 0, 0);
+                return seven;
+                }()''')
+           }
+    """
+
+    def __init__(self, code):
+        self.code = code
+
+    def __str__(self):
+        return self.code
+
+
 class PickerWidgetMixin(object):
 
     format_name = None


### PR DESCRIPTION
Hi,

I found myself wanting to inject some Javascript code as the value for the 'initialDate' object but it would get quoted if it goes in as a string so I've added a helper object to get around it.

Details in the doc-string. If you feel it is useful, I'd be happy to try to update the README as well (which I now realised I've forgotten to do!)

Cheers,
Michael
