### PR TITLE
Move todayBtn to quoted_bool_options

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -1,12 +1,11 @@
 
 __author__ = 'Alfredo Saglimbeni'
 
-from datetime import datetime
 import re
 import uuid
 
-from django.forms import forms, widgets
-from django.forms.widgets import MultiWidget, DateTimeInput, DateInput, TimeInput
+from django.forms import widgets
+from django.forms.widgets import DateTimeInput, DateInput, TimeInput
 from django.utils.formats import get_format, get_language
 from django.utils.safestring import mark_safe
 from django.utils.six import string_types
@@ -14,7 +13,7 @@ from django.utils.six import string_types
 try:
     from django.forms.widgets import to_current_timezone
 except ImportError:
-    to_current_timezone = lambda obj: obj # passthrough, no tz support
+    to_current_timezone = lambda obj: obj  # passthrough, no tz support
 
 
 # This should be updated as more .po files are added to the datetime picker javascript code
@@ -38,7 +37,7 @@ supported_languages = set([
     'th', 'tr',
     'ua', 'uk',
     'zh-CN', 'zh-TW',
-    ])
+])
 
 
 def get_supported_language(language_country_code):
@@ -121,7 +120,7 @@ BOOTSTRAP_INPUT_TEMPLATE = {
            $(function(){$("#%(id)s").datetimepicker({%(options)s}).find('input').addClass("form-control");});
        </script>
        """
-       }
+}
 
 CLEAR_BTN_TEMPLATE = {2: """<span class="add-on"><i class="icon-remove"></i></span>""",
                       3: """<span class="input-group-addon"><span class="glyphicon glyphicon-remove"></span></span>"""}
@@ -143,7 +142,7 @@ quoted_options = set([
     'weekStart',
     'minuteStep'
     'daysOfWeekDisabled',
-    ])
+])
 
 # to traslate boolean object to javascript
 quoted_bool_options = set([
@@ -152,7 +151,7 @@ quoted_bool_options = set([
     'showMeridian',
     'clearBtn',
     'todayBtn',
-    ])
+])
 
 
 def quote(key, value):
@@ -165,7 +164,7 @@ def quote(key, value):
         return "'%s'" % value
 
     if key in quoted_bool_options and isinstance(value, bool):
-        return {True:'true',False:'false'}[value]
+        return {True: 'true', False: 'false'}[value]
 
     return value
 
@@ -177,7 +176,7 @@ class PickerWidgetMixin(object):
 
     def __init__(self, attrs=None, options=None, usel10n=None, bootstrap_version=None):
 
-        if bootstrap_version in [2,3]:
+        if bootstrap_version in [2, 3]:
             self.bootstrap_version = bootstrap_version
         else:
             # default 2 to mantain support to old implemetation of django-datetime-widget
@@ -206,7 +205,7 @@ class PickerWidgetMixin(object):
             self.options['format'] = toJavascript_re.sub(
                 lambda x: dateConversiontoJavascript[x.group()],
                 self.format
-                )
+            )
 
             # Set the local language
             self.options['language'] = get_supported_language(get_language())
@@ -219,7 +218,7 @@ class PickerWidgetMixin(object):
             self.format = toPython_re.sub(
                 lambda x: dateConversiontoPython[x.group()],
                 format
-                )
+            )
 
         super(PickerWidgetMixin, self).__init__(attrs, format=self.format)
 
@@ -227,7 +226,7 @@ class PickerWidgetMixin(object):
         final_attrs = self.build_attrs(attrs)
         rendered_widget = super(PickerWidgetMixin, self).render(name, value, final_attrs)
 
-        #if not set, autoclose have to be true.
+        # if not set, autoclose have to be true.
         self.options.setdefault('autoclose', True)
 
         # Build javascript options out of python dictionary
@@ -240,19 +239,19 @@ class PickerWidgetMixin(object):
         # Use provided id or generate hex to avoid collisions in document
         id = final_attrs.get('id', uuid.uuid4().hex)
 
-        clearBtn = quote('clearBtn', self.options.get('clearBtn', 'true')) == 'true'
-        labelField = final_attrs.get('label', False)
+        clear_btn = quote('clearBtn', self.options.get('clearBtn', 'true')) == 'true'
+        label_field = final_attrs.get('label', False)
 
         return mark_safe(
             BOOTSTRAP_INPUT_TEMPLATE[self.bootstrap_version]
-                % dict(
-                    id=id,
-                    rendered_widget=rendered_widget,
-                    label=LABEL_TEMPLATE[self.bootstrap_version] % dict(label=labelField) if labelField else "",
-                    clear_button=CLEAR_BTN_TEMPLATE[self.bootstrap_version] if clearBtn else "",
-                    glyphicon=self.glyphicon,
-                    options=js_options
-                    )
+            % dict(
+                id=id,
+                rendered_widget=rendered_widget,
+                label=LABEL_TEMPLATE[self.bootstrap_version] % dict(label=label_field) if label_field else "",
+                clear_button=CLEAR_BTN_TEMPLATE[self.bootstrap_version] if clear_btn else "",
+                glyphicon=self.glyphicon,
+                options=js_options
+            )
         )
 
     def _media(self):
@@ -266,14 +265,15 @@ class PickerWidgetMixin(object):
         return widgets.Media(
             css={
                 'all': ('css/datetimepicker.css',)
-                },
+            },
             js=js
-            )
+        )
 
     media = property(_media)
 
 
 class DateTimeWidget(PickerWidgetMixin, DateTimeInput):
+
     """
     DateTimeWidget is the corresponding widget for Datetime field, it renders both the date and time
     sections of the datetime picker.
@@ -294,6 +294,7 @@ class DateTimeWidget(PickerWidgetMixin, DateTimeInput):
 
 
 class DateWidget(PickerWidgetMixin, DateInput):
+
     """
     DateWidget is the corresponding widget for Date field, it renders only the date section of
     datetime picker.
@@ -316,6 +317,7 @@ class DateWidget(PickerWidgetMixin, DateInput):
 
 
 class TimeWidget(PickerWidgetMixin, TimeInput):
+
     """
     TimeWidget is the corresponding widget for Time field, it renders only the time section of
     datetime picker.
@@ -336,4 +338,3 @@ class TimeWidget(PickerWidgetMixin, TimeInput):
         options['format'] = options.get('format', 'hh:ii')
 
         super(TimeWidget, self).__init__(attrs, options, usel10n, bootstrap_version)
-

--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -136,7 +136,6 @@ quoted_options = set([
     'startView',
     'minView',
     'maxView',
-    'todayBtn',
     'language',
     'pickerPosition',
     'viewSelect',
@@ -152,6 +151,7 @@ quoted_bool_options = set([
     'todayHighlight',
     'showMeridian',
     'clearBtn',
+    'todayBtn',
     ])
 
 


### PR DESCRIPTION
`todayBtn` is currently under `quoted_options` instead of `quoted_bool_options` causing the widget to fail when `todayBtn` is added as a Boolean option.
