### PR TITLE
Full Month Textual Representation

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -76,6 +76,7 @@ dateConversiontoPython = {
     'HH': '%I',
     'dd': '%d',
     'mm': '%m',
+    'MM': '%B',
     'yy': '%y',
     'yyyy': '%Y',
 }
@@ -86,6 +87,7 @@ toPython_re = re.compile(r'\b(' + '|'.join(dateConversiontoPython.keys()) + r')\
 dateConversiontoJavascript = {
     '%M': 'ii',
     '%m': 'mm',
+    '%B': 'MM',
     '%I': 'HH',
     '%H': 'hh',
     '%d': 'dd',


### PR DESCRIPTION
When I was trying to use the full textual representation of the month, ie. 'November' I noticed that when I loaded my update form, the form filled the month as 'MM' instead of the actual month name. I noticed that in the code there was a conversion list of the date representations so I went ahead and added it and it fixed the issue for me. 
BEFORE:
![screenshot 2015-11-22 12 04 29](https://cloud.githubusercontent.com/assets/6207077/11325068/03b511ec-9112-11e5-896c-f48767ac5c8b.png)
AFTER:
![screenshot 2015-11-22 12 03 55](https://cloud.githubusercontent.com/assets/6207077/11325069/03b7a43e-9112-11e5-9de0-2041b50b5317.png)
