### PR TITLE
Allow custom localised datetime format

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -196,7 +196,7 @@ class PickerWidgetMixin(object):
             self.is_localized = True
 
             # Get format from django format system
-            self.format = get_format(self.format_name)[0]
+            self.format = self.options['format'] or get_format(self.format_name)[0]
 
             # Convert Python format specifier to Javascript format specifier
             self.options['format'] = toJavascript_re.sub(


### PR DESCRIPTION
At the moment the 'format' option is ignored if 'usel10n' is set to True.  This change uses the 'format' option in the case that it is specified - even if 'usel10n' is set to True.
