### PR TITLE
Fix prev & next buttons on initial load

### DIFF
--- a/datetimewidget/static/js/bootstrap-datetimepicker.js
+++ b/datetimewidget/static/js/bootstrap-datetimepicker.js
@@ -122,7 +122,7 @@
 
 		this.startViewMode = 2;
 		if ('startView' in options) {
-			this.startViewMode = options.startView;
+			this.startViewMode = parseInt(options.startView);
 		} else if ('startView' in this.element.data()) {
 			this.startViewMode = this.element.data('start-view');
 		}


### PR DESCRIPTION
The previous and next buttons currently do not work when the widget is initially loaded.
This is caused when the startView option comes through as a string and the switch case for enabling these buttons is skipped.
This fix ensures the startView option is interpreted as an integer.
