### PR TITLE
feat: solve readonly/required conflict

### DIFF
--- a/datetimewidget/static/js/django-datetime-widget.js
+++ b/datetimewidget/static/js/django-datetime-widget.js
@@ -1,0 +1,6 @@
+$(document).ready(function() {
+    $("div.ddw-requirable-readonly>input").on('keydown paste', function (e) {
+        e.preventDefault();
+    });
+});
+

--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -100,7 +100,7 @@ toJavascript_re = re.compile(r'(?<!\w)(' + '|'.join(dateConversiontoJavascript.k
 
 BOOTSTRAP_INPUT_TEMPLATE = {
     2: """
-       <div id="%(id)s"  class="controls input-append date">
+       <div id="%(id)s"  class="controls input-append date %(ddw_classes)s">
            %(rendered_widget)s
            %(clear_button)s
            <span class="add-on"><i class="icon-th"></i></span>
@@ -110,7 +110,7 @@ BOOTSTRAP_INPUT_TEMPLATE = {
        </script>
        """,
     3: """
-       <div id="%(id)s" class="input-group date">
+       <div id="%(id)s" class="input-group date %(ddw_classes)s">
            %(rendered_widget)s
            %(clear_button)s
            <span class="input-group-addon"><span class="glyphicon %(glyphicon)s"></span></span>
@@ -221,6 +221,12 @@ class PickerWidgetMixin(object):
 
     def render(self, name, value, attrs=None):
         final_attrs = self.build_attrs(attrs)
+
+        ddw_classes = []
+        if 'required' in final_attrs and 'readonly' in final_attrs:
+            final_attrs.pop('readonly')
+            ddw_classes.append('ddw-requirable-readonly')
+
         rendered_widget = super(PickerWidgetMixin, self).render(name, value, final_attrs)
 
         #if not set, autoclose have to be true.
@@ -245,13 +251,14 @@ class PickerWidgetMixin(object):
                     rendered_widget=rendered_widget,
                     clear_button=CLEAR_BTN_TEMPLATE[self.bootstrap_version] if clearBtn else "",
                     glyphicon=self.glyphicon,
-                    options=js_options
+                    options=js_options,
+                    ddw_classes=' '.join(ddw_classes),
                     )
         )
 
     def _media(self):
 
-        js = ["js/bootstrap-datetimepicker.js"]
+        js = ["js/bootstrap-datetimepicker.js", "js/django-datetime-widget.js"]
 
         language = self.options.get('language', 'en')
         if language != 'en':


### PR DESCRIPTION
Since this widget makes the input `readonly` by default, browsers' built-in validation is not performed for required fields before form submission. This becomes an annoying problem when the form has file field(s), since validation occurs on server and the form returns with empty file inputs.

This feature removes the `readonly` attribute if `required` is present and mimics the `readonly` behaviour with jquery. With this, browser's validation will be performed.

May be there is a better way of solving this, I'm open to any suggestions!

Hector.