### PR TITLE
Delay JS parsing until Document Ready

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -106,7 +106,10 @@ BOOTSTRAP_INPUT_TEMPLATE = {
            <span class="add-on"><i class="icon-th"></i></span>
        </div>
        <script type="text/javascript">
-           $("#%(id)s").datetimepicker({%(options)s});
+           var DOMReady = function(a,b,c){b=document,c='addEventListener';b[c]?b[c]('DOMContentLoaded',a):window.attachEvent('onload',a)}
+           DOMReady(function(){
+               $("#%(id)s").datetimepicker({%(options)s});
+           });
        </script>
        """,
     3: """
@@ -116,7 +119,10 @@ BOOTSTRAP_INPUT_TEMPLATE = {
            <span class="input-group-addon"><span class="glyphicon %(glyphicon)s"></span></span>
        </div>
        <script type="text/javascript">
-           $("#%(id)s").datetimepicker({%(options)s}).find('input').addClass("form-control");
+           var DOMReady = function(a,b,c){b=document,c='addEventListener';b[c]?b[c]('DOMContentLoaded',a):window.attachEvent('onload',a)}
+           DOMReady(function(){
+               $("#%(id)s").datetimepicker({%(options)s}).find('input').addClass("form-control");
+           });
        </script>
        """
        }


### PR DESCRIPTION
Best practice advises loading jQuery and other JS libraries at the end of a page’s HTML. To allow for correct operation in projects loading jQuery at the foot of the document, this PR wraps the inline <script> tag contents in a browser-compatible DOM Ready event handler lifted from here: https://gist.github.com/dciccale/4087856.

This improves upon #72 by being more cross-browser compatible.