### PR TITLE
Python 3 + Django 2.2+ support

### DIFF
--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -9,7 +9,7 @@ from django.forms import forms, widgets
 from django.forms.widgets import MultiWidget, DateTimeInput, DateInput, TimeInput
 from django.utils.formats import get_format, get_language
 from django.utils.safestring import mark_safe
-from django.utils.six import string_types
+from six import string_types
 
 try:
     from django.forms.widgets import to_current_timezone

--- a/datetimewidget/widgets.py
+++ b/datetimewidget/widgets.py
@@ -219,7 +219,7 @@ class PickerWidgetMixin(object):
 
         super(PickerWidgetMixin, self).__init__(attrs, format=self.format)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         final_attrs = self.build_attrs(attrs)
         rendered_widget = super(PickerWidgetMixin, self).render(name, value, final_attrs)
 


### PR DESCRIPTION
- 2.x and newer versions of Django require Python 3, which includes package `six` by default. Therefore this no longer needs to be imported from django.utils.

- Also, Widget.render() method has an additional optional parameter `renderer=None`.

This PR makes these two changes necessary for the package to work with Django 2.2+.